### PR TITLE
添加导入导出配装json的enhancementNodeValues字段压缩

### DIFF
--- a/internal/backend/loadout_import_scope_test.go
+++ b/internal/backend/loadout_import_scope_test.go
@@ -47,9 +47,9 @@ func TestMasterProgressSelectionPreservesSourceTotalOrUsesAuditedThreshold(t *te
 	}
 }
 
-func TestLoadoutShareVersionTenCarriesExactRuntimeSnapshots(t *testing.T) {
-	if loadoutShareVersion != 10 {
-		t.Fatalf("loadout share version=%d, want 10", loadoutShareVersion)
+func TestLoadoutShareVersionElevenCarriesExactRuntimeSnapshots(t *testing.T) {
+	if loadoutShareVersion != 11 {
+		t.Fatalf("loadout share version=%d, want 11", loadoutShareVersion)
 	}
 	payload := LoadoutImportApplyPayload{}
 	if payload.ApplyCharacterLevel || payload.ApplyMasteryConfiguration || payload.ApplyMasterProgress || payload.ApplyCharacterGrowth || payload.ApplyCharacterWeaponCollection || payload.ApplyCharacterWeaponWrightstones ||

--- a/internal/backend/loadout_share.go
+++ b/internal/backend/loadout_share.go
@@ -1,6 +1,8 @@
 package backend
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -14,8 +16,10 @@ import (
 const (
 	loadoutShareFormat        = "gbfr-loadout"
 	loadoutShareLegacyVersion = 1
-	loadoutShareVersion       = 10
+	loadoutShareVersion       = 11
 	loadoutShareMaxSize       = 1024 * 1024
+	enhancementNodeEncoding   = "rle-bitpack-v1"
+	enhancementNodeLimit      = 1000
 )
 
 // LoadoutShareSigil 使用“因子本体 + 等级 + 主副词条 + 词条等级”指纹。
@@ -45,26 +49,159 @@ type LoadoutShareSummon struct {
 }
 
 type LoadoutShareCharacterProgression struct {
-	CharacterLevel             int                             `json:"characterLevel,omitempty"`
-	BaseHP                     int                             `json:"baseHp,omitempty"`
-	BaseATK                    int                             `json:"baseAtk,omitempty"`
-	BaseStunBits               uint32                          `json:"baseStunBits,omitempty"`
-	BaseCritRate               int                             `json:"baseCritRate,omitempty"`
-	CharacterBaseCaptured      bool                            `json:"characterBaseCaptured,omitempty"`
-	MasterTotalMSP             int                             `json:"masterTotalMsp"`
-	LegacyProgress             int                             `json:"legacyProgress"`
-	EnhancementPanel           []int                           `json:"enhancementPanel,omitempty"`
-	EnhancementNodes           []LoadoutShareEnhancementNode   `json:"enhancementNodes,omitempty"`
-	EnhancementNodeValues      []int                           `json:"enhancementNodeValues,omitempty"`
-	Weapons                    []LoadoutShareProgressionWeapon `json:"weapons,omitempty"`
-	WeaponWrightstonesCaptured bool                            `json:"weaponWrightstonesCaptured,omitempty"`
+	CharacterLevel             int                               `json:"characterLevel,omitempty"`
+	BaseHP                     int                               `json:"baseHp,omitempty"`
+	BaseATK                    int                               `json:"baseAtk,omitempty"`
+	BaseStunBits               uint32                            `json:"baseStunBits,omitempty"`
+	BaseCritRate               int                               `json:"baseCritRate,omitempty"`
+	CharacterBaseCaptured      bool                              `json:"characterBaseCaptured,omitempty"`
+	MasterTotalMSP             int                               `json:"masterTotalMsp"`
+	LegacyProgress             int                               `json:"legacyProgress"`
+	EnhancementPanel           []int                             `json:"enhancementPanel,omitempty"`
+	EnhancementNodes           []LoadoutShareEnhancementNode     `json:"enhancementNodes,omitempty"`
+	EnhancementNodeValues      LoadoutShareEnhancementNodeValues `json:"enhancementNodeValues,omitempty"`
+	Weapons                    []LoadoutShareProgressionWeapon   `json:"weapons,omitempty"`
+	WeaponWrightstonesCaptured bool                              `json:"weaponWrightstonesCaptured,omitempty"`
 }
 
-func compactEnhancementNodeValues(nodes []LoadoutShareEnhancementNode) ([]int, bool) {
+type LoadoutShareEnhancementNodeValues []int
+
+type packedEnhancementNodeValues struct {
+	Encoding  string `json:"encoding"`
+	Count     int    `json:"count"`
+	ValueBits int    `json:"valueBits"`
+	RunBits   int    `json:"runBits"`
+	Data      string `json:"data"`
+}
+
+func bitsRequired(value int) int {
+	bits := 1
+	for value >>= 1; value > 0; value >>= 1 {
+		bits++
+	}
+	return bits
+}
+
+func appendPackedBits(data []byte, bitOffset *int, value, width int) {
+	for bit := 0; bit < width; bit++ {
+		if value&(1<<bit) != 0 {
+			data[*bitOffset/8] |= 1 << (*bitOffset % 8)
+		}
+		*bitOffset++
+	}
+}
+
+func readPackedBits(data []byte, bitOffset *int, width int) (int, error) {
+	if width <= 0 || *bitOffset+width > len(data)*8 {
+		return 0, fmt.Errorf("enhancementNodeValues 位流长度不足")
+	}
+	value := 0
+	for bit := 0; bit < width; bit++ {
+		if data[*bitOffset/8]&(1<<(*bitOffset%8)) != 0 {
+			value |= 1 << bit
+		}
+		*bitOffset++
+	}
+	return value, nil
+}
+
+func (values LoadoutShareEnhancementNodeValues) MarshalJSON() ([]byte, error) {
+	if len(values) == 0 {
+		return []byte("null"), nil
+	}
+	maxValue, maxRun, runCount := 0, 0, 0
+	for start := 0; start < len(values); {
+		if values[start] < 0 {
+			return nil, fmt.Errorf("enhancementNodeValues[%d] 不能为负数", start)
+		}
+		end := start + 1
+		for end < len(values) && values[end] == values[start] {
+			end++
+		}
+		maxValue = max(maxValue, values[start])
+		maxRun = max(maxRun, end-start)
+		runCount++
+		start = end
+	}
+	valueBits, runBits := bitsRequired(maxValue), bitsRequired(maxRun-1)
+	data := make([]byte, (runCount*(valueBits+runBits)+7)/8)
+	bitOffset := 0
+	for start := 0; start < len(values); {
+		end := start + 1
+		for end < len(values) && values[end] == values[start] {
+			end++
+		}
+		appendPackedBits(data, &bitOffset, values[start], valueBits)
+		appendPackedBits(data, &bitOffset, end-start-1, runBits)
+		start = end
+	}
+	return json.Marshal(packedEnhancementNodeValues{
+		Encoding: enhancementNodeEncoding, Count: len(values), ValueBits: valueBits, RunBits: runBits,
+		Data: base64.RawStdEncoding.EncodeToString(data),
+	})
+}
+
+func (values *LoadoutShareEnhancementNodeValues) UnmarshalJSON(payload []byte) error {
+	payload = bytes.TrimSpace(payload)
+	if bytes.Equal(payload, []byte("null")) {
+		*values = nil
+		return nil
+	}
+	var legacy []int
+	if len(payload) > 0 && payload[0] == '[' {
+		if err := json.Unmarshal(payload, &legacy); err != nil {
+			return err
+		}
+		*values = legacy
+		return nil
+	}
+	var packed packedEnhancementNodeValues
+	if err := json.Unmarshal(payload, &packed); err != nil {
+		return err
+	}
+	if packed.Encoding != enhancementNodeEncoding || packed.Count <= 0 || packed.Count > enhancementNodeLimit ||
+		packed.ValueBits <= 0 || packed.ValueBits > 31 || packed.RunBits <= 0 || packed.RunBits > 10 {
+		return fmt.Errorf("enhancementNodeValues 压缩参数无效")
+	}
+	data, err := base64.RawStdEncoding.DecodeString(packed.Data)
+	if err != nil {
+		return fmt.Errorf("enhancementNodeValues data 无效: %w", err)
+	}
+	decoded := make([]int, 0, packed.Count)
+	bitOffset := 0
+	for len(decoded) < packed.Count {
+		value, readErr := readPackedBits(data, &bitOffset, packed.ValueBits)
+		if readErr != nil {
+			return readErr
+		}
+		runMinusOne, readErr := readPackedBits(data, &bitOffset, packed.RunBits)
+		if readErr != nil {
+			return readErr
+		}
+		run := runMinusOne + 1
+		if run > packed.Count-len(decoded) {
+			return fmt.Errorf("enhancementNodeValues RLE 长度超过声明节点数")
+		}
+		for range run {
+			decoded = append(decoded, value)
+		}
+	}
+	usedBytes := (bitOffset + 7) / 8
+	if len(data) != usedBytes {
+		return fmt.Errorf("enhancementNodeValues data 包含多余数据")
+	}
+	if paddingBits := usedBytes*8 - bitOffset; paddingBits > 0 && data[usedBytes-1]>>(8-paddingBits) != 0 {
+		return fmt.Errorf("enhancementNodeValues data 的填充位非零")
+	}
+	*values = decoded
+	return nil
+}
+
+func compactEnhancementNodeValues(nodes []LoadoutShareEnhancementNode) (LoadoutShareEnhancementNodeValues, bool) {
 	if len(nodes) == 0 {
 		return nil, false
 	}
-	values := make([]int, len(nodes))
+	values := make(LoadoutShareEnhancementNodeValues, len(nodes))
 	for index, node := range nodes {
 		if node.Index != index {
 			return nil, false
@@ -78,8 +215,8 @@ func normalizeEnhancementNodeValues(character *LoadoutShareCharacterProgression)
 	if character == nil || len(character.EnhancementNodeValues) == 0 {
 		return nil
 	}
-	if len(character.EnhancementNodeValues) > 1000 {
-		return fmt.Errorf("enhancementNodeValues 超过 1000 个节点")
+	if len(character.EnhancementNodeValues) > enhancementNodeLimit {
+		return fmt.Errorf("enhancementNodeValues 超过 %d 个节点", enhancementNodeLimit)
 	}
 	character.EnhancementNodes = make([]LoadoutShareEnhancementNode, len(character.EnhancementNodeValues))
 	for index, value := range character.EnhancementNodeValues {

--- a/internal/backend/loadout_share_code.go
+++ b/internal/backend/loadout_share_code.go
@@ -653,7 +653,10 @@ func decodeLoadoutShareCode(code string) (*LoadoutShare, error) {
 		if err := msgpack.Unmarshal(packed, compact); err != nil {
 			return nil, fmt.Errorf("解析紧凑配装失败: %w", err)
 		}
-		if err := validateCompactLoadoutShare(compact, loadoutShareVersion, true); err != nil {
+		if compact.ShareVersion != 10 && compact.ShareVersion != loadoutShareVersion {
+			return nil, fmt.Errorf("分享码内的配装版本为 v%d，当前帧支持 v10..v%d", compact.ShareVersion, loadoutShareVersion)
+		}
+		if err := validateCompactLoadoutShare(compact, compact.ShareVersion, true); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/backend/loadout_share_code_test.go
+++ b/internal/backend/loadout_share_code_test.go
@@ -182,6 +182,47 @@ func legacyLoadoutShareCodeFixture(t *testing.T, source *LoadoutShare) string {
 	return loadoutShareCodePrefix + base64.RawURLEncoding.EncodeToString(frame)
 }
 
+func shareCodeFrameFixture(t *testing.T, compact *loadoutShareCodePayload, frameVersion byte) string {
+	t.Helper()
+	packed, err := msgpack.Marshal(compact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var compressed bytes.Buffer
+	writer := brotli.NewWriterLevel(&compressed, brotli.BestCompression)
+	if _, err := writer.Write(packed); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	frame := make([]byte, loadoutShareCodeHeaderSize, loadoutShareCodeHeaderSize+compressed.Len())
+	copy(frame[:4], loadoutShareCodeFrameMagic)
+	frame[4] = frameVersion
+	frame[5] = loadoutShareCodeCodec
+	binary.LittleEndian.PutUint32(frame[6:10], uint32(len(packed)))
+	binary.LittleEndian.PutUint32(frame[10:14], crc32.ChecksumIEEE(packed))
+	binary.LittleEndian.PutUint32(frame[14:18], uint32(compressed.Len()))
+	frame = append(frame, compressed.Bytes()...)
+	return loadoutShareCodePrefix + base64.RawURLEncoding.EncodeToString(frame)
+}
+
+func TestLoadoutShareCodeStillDecodesV10Frame(t *testing.T) {
+	source := loadoutShareCodeFixture()
+	compact, err := compactLoadoutShare(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compact.ShareVersion = 10
+	decoded, err := decodeLoadoutShareCode(shareCodeFrameFixture(t, compact, loadoutShareCodeFrameVersion))
+	if err != nil {
+		t.Fatalf("decode v10 frame: %v", err)
+	}
+	if decoded.Version != 10 || decoded.Character == nil || !reflect.DeepEqual(decoded.Character.EnhancementNodes, source.Character.EnhancementNodes) {
+		t.Fatalf("v10 frame changed during decode: %+v", decoded)
+	}
+}
+
 func TestLoadoutShareCodeStillDecodesLegacyV8Frame(t *testing.T) {
 	source := loadoutShareCodeFixture()
 	decoded, err := decodeLoadoutShareCode(legacyLoadoutShareCodeFixture(t, source))

--- a/internal/backend/loadout_share_test.go
+++ b/internal/backend/loadout_share_test.go
@@ -44,11 +44,14 @@ func TestLoadoutShareExportUsesReadableCompactJSON(t *testing.T) {
 	if !strings.Contains(string(payload), "\n  \"character\"") {
 		t.Fatalf("loadout export is not human-readable JSON: %q", payload)
 	}
-	if strings.Contains(string(payload), `"enhancementNodes"`) || !strings.Contains(string(payload), `"enhancementNodeValues"`) {
-		t.Fatalf("v10 export did not replace repeated node index/value objects: %s", payload)
+	if strings.Contains(string(payload), `"enhancementNodes"`) || !strings.Contains(string(payload), `"enhancementNodeValues": {`) || !strings.Contains(string(payload), `"encoding": "rle-bitpack-v1"`) {
+		t.Fatalf("v11 export did not RLE/bit-pack enhancement node values: %s", payload)
 	}
-	if len(payload) >= 12000 {
-		t.Fatalf("v10 fixed-position node array is unexpectedly large: %d bytes", len(payload))
+	if strings.Contains(string(payload), `"enhancementNodeValues": [`) {
+		t.Fatalf("v11 export still contains the uncompressed node array: %s", payload)
+	}
+	if len(payload) >= 2000 {
+		t.Fatalf("v11 packed node data is unexpectedly large: %d bytes", len(payload))
 	}
 	decoded, err := unmarshalLoadoutShare(payload)
 	if err != nil {
@@ -63,6 +66,48 @@ func TestLoadoutShareExportUsesReadableCompactJSON(t *testing.T) {
 	}
 	if !strings.Contains(string(apiPayload), `"enhancementNodes"`) || strings.Contains(string(apiPayload), `"enhancementNodeValues"`) {
 		t.Fatalf("API/Wails JSON must keep enhancementNodes for the generated frontend model: %s", apiPayload)
+	}
+}
+
+func TestLoadoutShareStillReadsV10EnhancementNodeValues(t *testing.T) {
+	payload := []byte(`{"format":"gbfr-loadout","version":10,"character":{"enhancementNodeValues":[0,1,1,0,255]}}`)
+	share, err := unmarshalLoadoutShare(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []LoadoutShareEnhancementNode{{Index: 0, Value: 0}, {Index: 1, Value: 1}, {Index: 2, Value: 1}, {Index: 3, Value: 0}, {Index: 4, Value: 255}}
+	if share.Character == nil || !reflect.DeepEqual(share.Character.EnhancementNodes, want) {
+		t.Fatalf("v10 enhancementNodeValues were not restored: %+v", share.Character)
+	}
+}
+
+func TestLoadoutShareRejectsInvalidPackedEnhancementNodeValues(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		payload string
+	}{
+		{name: "未知编码", payload: `{"encoding":"unknown","count":4,"valueBits":1,"runBits":2,"data":"AA"}`},
+		{name: "位流截断", payload: `{"encoding":"rle-bitpack-v1","count":4,"valueBits":8,"runBits":3,"data":"AA"}`},
+		{name: "RLE越界", payload: `{"encoding":"rle-bitpack-v1","count":2,"valueBits":1,"runBits":3,"data":"DA"}`},
+		{name: "多余字节", payload: `{"encoding":"rle-bitpack-v1","count":1,"valueBits":1,"runBits":1,"data":"AAA"}`},
+		{name: "非零填充位", payload: `{"encoding":"rle-bitpack-v1","count":1,"valueBits":1,"runBits":1,"data":"BA"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := []byte(`{"format":"gbfr-loadout","version":11,"character":{"enhancementNodeValues":` + tc.payload + `}}`)
+			if _, err := unmarshalLoadoutShare(payload); err == nil {
+				t.Fatalf("invalid packed enhancementNodeValues was accepted: %s", tc.payload)
+			}
+		})
+	}
+}
+
+func TestLoadoutShareReadsNullEnhancementNodeValues(t *testing.T) {
+	share, err := unmarshalLoadoutShare([]byte(`{"format":"gbfr-loadout","version":10,"character":{"enhancementNodeValues": null}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if share.Character == nil || len(share.Character.EnhancementNodes) != 0 {
+		t.Fatalf("null enhancementNodeValues changed character data: %+v", share.Character)
 	}
 }
 


### PR DESCRIPTION
## 改动说明

压缩单套角色配装 JSON 中的 `character.enhancementNodeValues` 字段，减少强化节点快照占用的文件体积。

新格式使用 **RLE + Bit Packing** 编码，并通过 Base64 保存压缩后的二进制数据。

实测相同配装导出大小对比 13,205 bytes  -> 10,061 bytes
## 主要改动

- 将配装 JSON 格式版本从 `v10` 升级至 `v11`
- 导出 JSON 时压缩 `enhancementNodeValues`
- 使用 RLE 合并连续相同的节点值
- 根据最大节点值和最大连续长度动态计算 `valueBits` 与 `runBits`
- 使用 Bit Packing 存储 RLE 记录
- 使用 Base64 将压缩数据写入 JSON
- 导入时自动解压并恢复完整的强化节点数组
- 保持 Wails/API 使用的 `enhancementNodes` 数据结构不变

## JSON 格式

`v11` 的 `enhancementNodeValues` 格式如下：

```json
{
  "encoding": "rle-bitpack-v1",      编码格式标识
  "count": 400,                      解压后的节点总数
  "valueBits": 8,                    每个节点值使用的 Bit 数
  "runBits": 6,                      每个 RLE 连续长度使用的 Bit 数
  "data": "..."                      Bit Packing 后的 Base64 数据
}
```
## 向后兼容
导入功能继续兼容以下格式：

v10 的 enhancementNodeValues 整数数组
v9 及更早版本的 enhancementNodes 对象数组
enhancementNodeValues: null
现有 v10 紧凑分享码
旧版 v8 分享码帧

线上配装分享仍使用现有的 MessagePack + Brotli 二进制帧。本次修改不会改变服务器存储协议。